### PR TITLE
Docker not sending logs to stdout

### DIFF
--- a/app/deploy/docker-run.sh
+++ b/app/deploy/docker-run.sh
@@ -12,5 +12,4 @@ chmod -R 777 /static
 
 # run uwsgi
 cd /app/
-#exec uwsgi --ini settings/uwsgi.ini >> /var/log/uwsgi/uwsgi.log 2>&1
-exec uwsgi >> /var/log/uwsgi/uwsgi.log 2>&1
+exec uwsgi


### PR DESCRIPTION
In order to get logging to our central logging system working, we have to log messages to stdout.  This change implements that by removing the redirect to a file.