### PR TITLE
Tidy up temporary Docker images after building/deploying

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 // tag image, push to repo, remove local tagged image
 def tag_image_as(tag) {
   script {
-    docker.image("${REPO_IMAGE}:${env.COMMIT_HASH}").push(tag)
-    sh "docker rmi ${REPO_IMAGE}:${tag} || true"
+    docker.image("${DOCKER_IMAGE_URL}:${env.COMMIT_HASH}").push(tag)
+    sh "docker rmi ${DOCKER_IMAGE_URL}:${tag} || true"
   }
 }
 
@@ -21,7 +21,7 @@ pipeline {
   agent any
   environment {
     APP = "looplijsten-api"
-    REPO_IMAGE = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/looplijsten"
+    DOCKER_IMAGE_URL = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/looplijsten"
   }
 
   stages {
@@ -56,7 +56,7 @@ pipeline {
 
       steps {
         script {
-          def image = docker.build("${REPO_IMAGE}:${env.COMMIT_HASH}",
+          def image = docker.build("${DOCKER_IMAGE_URL}:${env.COMMIT_HASH}",
             "--no-cache " +
             "--shm-size 1G " +
             " ./app")
@@ -92,7 +92,7 @@ pipeline {
     always {
       script {
         // delete original image built on the build server
-        sh "docker rmi ${REPO_IMAGE}:${env.COMMIT_HASH} || true"
+        sh "docker rmi ${DOCKER_IMAGE_URL}:${env.COMMIT_HASH} || true"
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def deploy(environment) {
   build job: 'Subtask_Openstack_Playbook',
     parameters: [
         [$class: 'StringParameterValue', name: 'INFRASTRUCTURE', value: 'secure'],
-        [$class: 'StringParameterValue', name: 'INVENTORY', value: 'acceptance'],
+        [$class: 'StringParameterValue', name: 'INVENTORY', value: environment],
         [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy-looplijsten-backend.yml'],
     ]
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,10 @@
 #!groovy
 
-def push_image(tag) {
+// tag image, push to repo, remove local tagged image
+def tag_image_as(tag) {
   script {
-    def image = docker.image("${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.COMMIT_HASH}")
-    image.push(tag)
+    docker.image("${REPO_IMAGE}:${env.COMMIT_HASH}").push(tag)
+    sh "docker rmi ${REPO_IMAGE}:${tag} || true"
   }
 }
 
@@ -19,9 +20,8 @@ def deploy(environment) {
 pipeline {
   agent any
   environment {
-    DOCKER_IMAGE = "fixxx/looplijsten"
     APP = "looplijsten-api"
-    DOCKER_REGISTRY = "repo.secure.amsterdam.nl"
+    REPO_IMAGE = "${DOCKER_REGISTRY_NO_PROTOCOL}/fixxx/looplijsten"
   }
 
   stages {
@@ -56,12 +56,12 @@ pipeline {
 
       steps {
         script {
-          def image = docker.build("${env.DOCKER_REGISTRY}/${env.DOCKER_IMAGE}:${env.COMMIT_HASH}",
+          def image = docker.build("${REPO_IMAGE}:${env.COMMIT_HASH}",
             "--no-cache " +
             "--shm-size 1G " +
             " ./app")
           image.push()
-          image.push("latest")
+          tag_image_as("latest")
         }
       }
     }
@@ -72,7 +72,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        push_image("acceptance")
+        tag_image_as("acceptance")
         deploy("acceptance")
       }
     }
@@ -80,11 +80,20 @@ pipeline {
     stage("Push and deploy production image") {
       when { buildingTag() }
       steps {
-        push_image("production")
-        push_image(env.TAG_NAME)
+        tag_image_as("production")
+        tag_image_as(env.TAG_NAME)
         deploy("production")
       }
     }
 
+  }
+
+  post {
+    always {
+      script {
+        // delete original image built on the build server
+        sh "docker rmi ${REPO_IMAGE}:${env.COMMIT_HASH} || true"
+      }
+    }
   }
 }


### PR DESCRIPTION
* The script now cleans up after itself by deleting (temporary) images after use.
* The script is also in some ways slightly simpler and easier to read.
* The URL of the Docker repository in no longer explicitly referenced.