### PR TITLE
Fix BWV sync

### DIFF
--- a/bwv_sync/Dockerfile
+++ b/bwv_sync/Dockerfile
@@ -5,7 +5,7 @@ RUN cargo build --release
 
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y cron postgresql-client curl
+RUN apt-get update && apt-get install -y cron postgresql-client curl tzdata
 
 COPY --from=pg_anonymize /app/target/release/pg_anonymize /usr/local/bin/
 COPY pg_anonymize.conf /etc/
@@ -17,6 +17,12 @@ RUN crontab /etc/cron.d/bwv-sync
 COPY bwv-sync.sh /usr/local/bin/looplijsten_bwv_sync.sh
 RUN chmod 755 /usr/local/bin/looplijsten_bwv_sync.sh
 
+COPY entrypoint.sh /
+RUN chmod 755 /entrypoint.sh
+
 RUN touch /var/log/cron.log
 
-CMD ["cron", "-f"]
+ENV TZ=Europe/Amsterdam
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+CMD /entrypoint.sh

--- a/bwv_sync/bwv-sync.cron
+++ b/bwv_sync/bwv-sync.cron
@@ -1,2 +1,2 @@
-35 5 * * * root /usr/local/bin/looplijsten_bwv_sync.sh
-26 16 * * * root /usr/local/bin/looplijsten_bwv_sync.sh
+35 5 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh
+26 16 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh

--- a/bwv_sync/entrypoint.sh
+++ b/bwv_sync/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# Write the container's environmental variables somewhere so we can source them
+# from the cronjobs (we need the passwords, after all).
+set -o allexport
+env > /root/env.env
+set +o allexport
+exec cron -f


### PR DESCRIPTION
* Make sure the sync script can access the container-level environmental
  variables (which contain passwords and such that we need);
* Make sure the timezone is set correctly, so the cronjobs are triggered
  at the time we expect them too.