### PR TITLE
reverse requirements because of errors. Issue is known

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,7 +3,7 @@ Django==3.1.2
 psycopg2
 
 # Rest apis
-djangorestframework==3.12.1
+djangorestframework==3.11.1
 django-cors-headers==3.4.0
 drf-spectacular==0.9.13
 


### PR DESCRIPTION
but prob needs migrations. Django rest is already using the new JSONField when it is not deprecated.