### PR TITLE
Vakantie indexes

### DIFF
--- a/bwv_sync/bwv-sync.cron
+++ b/bwv_sync/bwv-sync.cron
@@ -1,3 +1,3 @@
 35 5 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh >> /tmp/log 2>&1
 26 16 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh >> /tmp/log 2>&1
-
+* * * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh >> /tmp/log 2>&1

--- a/bwv_sync/bwv-sync.cron
+++ b/bwv_sync/bwv-sync.cron
@@ -1,2 +1,3 @@
-35 5 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh
-26 16 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh
+35 5 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh >> /tmp/log 2>&1
+26 16 * * * set -a; . /root/env.env; set +a;  /usr/local/bin/looplijsten_bwv_sync.sh >> /tmp/log 2>&1
+

--- a/bwv_sync/bwv-sync.sh
+++ b/bwv_sync/bwv-sync.sh
@@ -7,6 +7,7 @@
 
 # Let's make it easy to ourselves and prevent bash from interpreting the '*' in
 # 'select * from ...'
+echo "Starting sync"
 set -o noglob
 set -euo pipefail
 
@@ -46,12 +47,35 @@ tables=(
   view_woningen,bwv_woningen
 )
 
+# These indexes are needed by the vakantieverhuur fraud detection model
+indexes=(
+  "import_adres__adres_id_idx on import_adres (adres_id)"
+  "bwv_personen_hist__ads_id_idx on bwv_personen_hist (ads_id, vestigingsdatum_adres, vertrekdatum_adres)"
+  "bwv_personen_hist__pen_id_idx on bwv_personen_hist (pen_id, vestigingsdatum_adres)"
+  "import_stadia__stadia_id_idx on import_stadia (stadia_id varchar_pattern_ops)"
+  "bwv_hotline_melding__wng_id_idx on bwv_hotline_melding (wng_id)"
+  "bwv_personen__id_idx on bwv_personen (id)"
+  "import_wvs__adres_id__idx on import_wvs (adres_id)"
+)
+
+
 
 PGPASSWORD="${dst_pw}" psql -h "$dst_host" -U "$dst_user" -d "$dst_db" -c \
   "CREATE TABLE IF NOT EXISTS sync_log (start timestamp with time zone, finished timestamp with time zone);"
 PGPASSWORD="${dst_pw}" psql -h "$dst_host" -U "$dst_user" -d "$dst_db" -c \
   "INSERT INTO sync_log (start) VALUES ('${timestamp_start}');"
 
+# drop indexes
+echo "Dropping indexes..."
+for index in "${indexes[@]}"; do
+  echo "Dropping index ${index}..."
+  ixname=$(cut -d ' ' -f 1 <<< "$index")
+  PGPASSWORD="${dst_pw}" psql -h "${dst_host}" -U "${dst_user}" -d "$dst_db" -c "DROP INDEX IF EXISTS ${ixname}"
+done
+echo "Dropping indexes done."
+
+
+# Sync tables
 export PGPASSWORD="${src_pw}"
 for src_dst in ${tables[@]}; do
   src_table=$(cut -d, -f 1 <<<"$src_dst")
@@ -64,12 +88,25 @@ for src_dst in ${tables[@]}; do
     | if $anonymize; then /usr/local/bin/pg_anonymize -c /etc/pg_anonymize.conf "$dst_table"; else cat -; fi \
     | PGPASSWORD="${dst_pw}" psql -h "${dst_host}" -U "${dst_user}" -d "$dst_db" -c "COPY $dst_table FROM STDIN"
 done
+echo "Syncing tables done."
 
+
+# (re-)create indexes
+echo "Creating indexes..."
+for index in "${indexes[@]}"; do
+   echo "Creating '${index}'..."
+   PGPASSWORD="${dst_pw}" psql -h "${dst_host}" -U "${dst_user}" -d "$dst_db" -c "CREATE INDEX IF NOT EXISTS ${index}"
+done
+echo "Creating indexes done."
+
+echo "Logging success..."
 timestamp_finished="$(TZ="Europe/Amsterdam" date "+%Y-%m-%d %H:%M:%S Europe/Amsterdam")"
 PGPASSWORD="${dst_pw}" psql -h "$dst_host" -U "$dst_user" -d "$dst_db" -c \
   "UPDATE sync_log set finished = '${timestamp_finished}' where start = '${timestamp_start}';"
+echo "Logging success done.
 
 curl "${url}/api/v1/fraud-prediction/scoring/" \
   -X POST \
   -H "Accept: application/json" \
   -H "Authorization: ${fraud_prediction_secret_key}"
+

--- a/bwv_sync/bwv-sync.sh
+++ b/bwv_sync/bwv-sync.sh
@@ -109,4 +109,3 @@ curl "${url}/api/v1/fraud-prediction/scoring/" \
   -X POST \
   -H "Accept: application/json" \
   -H "Authorization: ${fraud_prediction_secret_key}"
-

--- a/bwv_sync/entrypoint.sh
+++ b/bwv_sync/entrypoint.sh
@@ -5,4 +5,9 @@
 set -o allexport
 env > /root/env.env
 set +o allexport
-exec cron -f
+echo "Starting cron..."
+touch /tmp/log
+cron
+echo "Running tail to capture output..."
+tail -f /tmp/log
+

--- a/bwv_sync/entrypoint.sh
+++ b/bwv_sync/entrypoint.sh
@@ -10,4 +10,3 @@ touch /tmp/log
 cron
 echo "Running tail to capture output..."
 tail -f /tmp/log
-


### PR DESCRIPTION
Add indexes for the vakantieverhuur model.

Also log the output of the sync script to stdout.

Since it is run by cron, the printing process is two-fold:
1. the output of the script is piped into a log file via the `cron` file
2. in the `entrypoint.sh` we start `cron` in the background now, and then tail-follow the log file
