### PR TITLE
Change username of credentials for accessing Onderhuur

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
           def image = docker.build("${DOCKER_IMAGE_URL}:${env.COMMIT_HASH}",
             "--no-cache " +
             "--shm-size 1G " +
-            "--build-arg ONDERHUUR_MODEL_CREDS=gitlab+deploy-token-176:${ONDERHUUR_MODEL_KEY} " +
+            "--build-arg ONDERHUUR_MODEL_CREDS=gitlab_token_onderhuur_model:${ONDERHUUR_MODEL_KEY} " +
             " ./app")
           image.push()
           tag_image_as("latest")


### PR DESCRIPTION
The GitLab deploy token was deleted by accident by the Onderhuur team on June 17. A new one has been created. An additional one has been created specifically for access from Looplijsten.
This Jenkins file uses a hardcoded username for the credentials. This username needs to be updated.