### PR TITLE
Add superuser script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ docker compose -f docker-compose.local.yml run --rm api python manage.py loaddat
 ```
 Remove the json fixture after installing it.
 
-## Creating a superuser:
+## Creating a superuser
+For accessing the Django admin during local development you'll have to become a `superuser`. This user should have the same `email` and `username` as the one that will be auto-created by the SSO login.
+
+Run the following command to either create the user, or make the existing one a superuser:
+
 ```bash
-docker compose -f docker-compose.local.yml run --rm api python manage.py createsuperuser
+sh bin/setup_superuser.sh <email>
 ```
-A superuser can be used to access the Django backend
 
 ## Accessing the Django admin and adding users:
 In order to generate lists you need at least 2 other users.

--- a/bin/setup_superuser.sh
+++ b/bin/setup_superuser.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Creates a superuser for the given `email` address, or updates if it already exists.
+#
+# Example usage:
+# ./bin/setup_superuser.sh user@amsterdam.nl
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <email>"
+    exit 1
+fi
+
+WEB_SERVICE_NAME="api"
+EMAIL="$1"
+
+docker compose -f docker-compose.local.yml run -T --rm "${WEB_SERVICE_NAME}" python manage.py shell <<PY
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+email = "${EMAIL}"
+
+user, created = User.objects.get_or_create(email=email, username=email)
+
+user.is_staff = True
+user.is_superuser = True
+user.is_active = True
+
+user.save()
+
+print(f"{'Created' if created else 'Updated'} superuser for {email}")
+PY


### PR DESCRIPTION
Created a simple script which should tackle the SSO issues I had the other day when setting up projects and creating a `superuser`. 

So this is to ensure that whatever you do first, the SSO-created user always aligns with creating or updating a superuser.

Scenarios tested:

✅ No user -> run this command (creates a superuser) -> visit the admin + loggin in via SSO;
✅ No user -> visit the frontend (which creates a user via SSO) -> run this command (upgrades to superuser) -> visit the admin;
✅ Existing user -> run this command (upgrades to super) (this is more or less the above scenario, given that the user was created via SSO and the username/email matches...)

Feedback or alternative solutions are welcome. If it looks good, we can implement it in other projects as well 👋